### PR TITLE
Topic: Added vim-timealloc plugin

### DIFF
--- a/vim-timealloc/README.md
+++ b/vim-timealloc/README.md
@@ -1,0 +1,18 @@
+# vim-timealloc plugin
+
+If you prefer using vim instead, this plugin is for you.
+You may map the `Timealloc*` commands to bindings that
+work for you.
+
+# Installation
+
+We recommend installing plugin via Pathogen, which can be found at
+[vim-pathogen](https://github.com/tpope/vim-pathogen), and follow
+the next steps:
+
+    mkdir -p ~/.vim/bundle
+    cd ~/.vim/bundle
+    git clone https://github.com/gthomsen/time-allocations.git
+
+Then open vim and run Pathogen's `:Helptags` command to
+generate tags for plugin documentation.

--- a/vim-timealloc/autoload/timealloc.vim
+++ b/vim-timealloc/autoload/timealloc.vim
@@ -1,0 +1,218 @@
+" Vim timealloc plugin file
+" Language:   TA-Lang
+" Maintainer: Polarsky
+
+if exists('g:autoloaded_timealloc')
+  finish
+endif
+let g:autoloaded_timealloc = 1
+
+"===========================================================
+" Functions: Formating
+"===========================================================
+" TimeallocSetCurrLine:
+"   in: string to replace line with
+function! timealloc#SetCurrLine( str )
+  call setline( line( '.' ), a:str )
+endfunction
+
+function! timealloc#AppendToCurrentLine( str )
+  call append( line('.'), a:str )
+  normal! J
+endfunction
+
+" Remove a character matching pattern
+"   in:  takes in a patter
+function! s:EatChar( pat )
+  let c = nr2char( getchar( 0 ) )
+  return ( c =~ a:pat ) ? '' : c
+endfunction
+
+" s:PostPad:
+"   in:  string
+"   in:  pad length
+"   in:  char to pad with
+"   Note: PostPad str with pad numer of char's
+function! s:PostPad( str, pad, ... )
+  if a:0 > 0
+    let char = a:1
+  else
+    let char = ' '
+  endif
+
+  return a:str . repeat( char, a:pad - len( a:str ) )
+endfunction
+
+" s:PrePad:
+"   in:  string
+"   in:  pad length
+"   in:  char to pad with
+"   Note: PrePad str with pad numer of char's
+function! s:PrePad( str, pad, ... )
+  if a:0 > 0
+    let char = a:1
+  else
+    let char = ' '
+  endif
+  return repeat( char, a:pad - len( a:str ) ) . a:str
+endfunction
+
+"===========================================================
+" Functions: Regex Matching
+"===========================================================
+" s:IsComment:
+"   in:  string line
+"   out: boolean
+"   Note: Checks if string line given is a comment string
+function! s:IsComment( str )
+  let match = matchstr( a:str , "#.*$" )
+  return !empty( match )
+endfunction
+
+" s:IsTimeStamp:
+"   in:  string word
+"   out: boolean
+"   Note: Checks if string word given is a time stamp
+function! s:IsTimeStamp( str )
+  let match = matchstr( a:str , "[0-9][0-9]:[0-9][0-9]" )
+  return !empty( match )
+endfunction
+
+"===========================================================
+" Functions: Time String Parsing
+"===========================================================
+" timealloc#GetTimeRange:
+"   Note: Returns a string of g:s:Granularity invervals
+function! timealloc#GetTimeRange()
+  let min   = strftime( "%M" )
+  let n_min = min
+  let hr    = strftime( "%H" )
+  let n_hr  = hr
+  let granu = g:TimeallocGranularity
+
+  if ( 0 ==# granu )
+    let granu = 1
+  endif
+
+  if ( granu/2 > min )
+    let min = float2nr( floor( min / (granu*1.0) ) ) * granu
+  else
+    let min = float2nr( ceil( min / (granu*1.0) ) ) * granu
+  endif
+  let n_min = min
+
+  if ( 60 ==# min )
+    let min    = 0
+    let n_min  = granu
+    let hr    += 1
+    let n_hr   = hr
+  else
+    let n_min += granu
+    if ( 60 ==# n_min )
+      n_min = 0'
+      n_hr += 1
+    endif
+  endif
+
+  let str_t1 = s:PrePad( hr, 2, '0' )   . ':' . s:PrePad( min, 2, '0' )
+  let str_t2 = s:PrePad( n_hr, 2, '0' ) . ':' . s:PrePad( n_min, 2, '0' )
+
+  return str_t1 . '-' . str_t2
+endfunction
+
+" s:GetTimeStampRanges:
+"   in:  a line string
+"   out: a string of time stamp ranges found in that line string
+"   Note: returns string of all time stamp ranges in line
+"   XXX: Does not remove repeated time stamp ranges
+function! s:GetTimeStampRanges( str )
+  let stamp_ranges = ''
+
+  if ( !s:IsComment( a:str ) )
+    let line_arr = split( a:str )
+    for word in line_arr
+      if ( s:IsTimeStamp( word ) )
+        let stamp_ranges = stamp_ranges . word . ' '
+      endif
+    endfor
+  endif
+
+  return stamp_ranges
+endfunction
+
+" s:GetTimeStamps:
+"   in:  a line string
+"   out: a string of time stamps found in that line string
+"   Note: empty string returned for comment lines
+"   XXX: Does not remove repeated time stamp ranges
+function! s:GetTimeStamps( str )
+  let stamps = ''
+
+  if ( !s:IsComment( a:str ) )
+    let line_arr = split( a:str )
+    for word in line_arr
+      let word_arr = split( word, '-' )
+      for sword in word_arr
+        if ( s:IsTimeStamp( sword ) )
+          let stamps = stamps . sword . ' '
+        endif
+      endfor
+    endfor
+  endif
+
+  return stamps
+endfunction
+
+" s:SumOfTimeStamps:
+"   in:  string of time stamps like so:
+"        00:00-00:00 00:00-00:00
+"   out: string of the float of total hours found in time stamps
+"   Note: Adds time stamp ranges
+"   XXX: Function does not check for invalid timestamps
+function! s:SumOfTimeStamps( time_stamps )
+  let time_stamps_arr = split( a:time_stamps )
+  let hrs_sum         = 0
+
+  for time in time_stamps_arr
+    let time    = split( time, ':' )
+    let hr      = time[0]*1.0 + time[1]/60.0
+    let hrs_sum = abs( hr - hrs_sum )
+  endfor
+
+  let hrs_sum_inte = float2nr(hrs_sum)
+  let hrs_sum_frac = float2nr( (hrs_sum - hrs_sum_inte*1.0) * 100 )
+
+  if ( 0 ==# hrs_sum_frac )
+    return hrs_sum_inte
+  else
+    return hrs_sum_inte . '.' . hrs_sum_frac
+  endif
+endfunction
+
+" timealloc#UpdateTimeStampLine:
+"   in:  gets current line at cursor
+"   out: appends to end of current line at cursor total hours
+"   Note: current line at cursor must not be a comment line
+"         or line not containing solely timestamps
+function! timealloc#UpdateTimeStampLine()
+  let curr_line = getline( '.' )
+  if ( s:IsComment( curr_line ) )
+    echom 'timealloc:Error: Line is a comment cannot update time'
+    return curr_line
+  endif
+
+  let stamps = s:GetTimeStamps( curr_line )
+  if ( empty( stamps ) )
+    echom 'timealloc:Error: Line contains no time stamps'
+    return curr_line
+  endif
+
+  let hrs = s:SumOfTimeStamps( stamps )
+  if ( empty( hrs ) )
+    let hrs = '0'
+  endif
+
+  let stamp_ranges = s:GetTimeStampRanges( curr_line )
+  normal! 0D
+  return stamp_ranges . '(' . hrs . ' hours)'
+endfunction

--- a/vim-timealloc/doc/timealloc.txt
+++ b/vim-timealloc/doc/timealloc.txt
@@ -1,0 +1,91 @@
+*timealloc.txt* functionality for the timealloc language
+
+               _______                      ____
+              /_  __(_)___ ___  ___  ____ _/ / /___  _____
+               / / / / __ `__ \/ _ \/ __ `/ / / __ \/ ___/
+              / / / / / / / / /  __/ /_/ / / / /_/ / /__
+             /_/ /_/_/ /_/ /_/\___/\__,_/_/_/\____/\___/
+                                               Vim Edition
+
+         A time management language and tool for terminal users.
+                                              - Polarsky, 2019 -
+
+
+====================================================================
+CONTENTS                                         *TimeallocContents*
+
+    1. Usage ................ |TimeallocUsage|
+    2. Mappings ............. |TimeallocMappings|
+    3. License .............. |TimeallocLicense|
+    4. Bugs ................. |TimeallocBugs|
+    5. Contributing ......... |TimeallocContributing|
+    6. Changelog ............ |TimeallocChangelog|
+    7. Credits .............. |TimeallocCredits|
+
+====================================================================
+USAGE                                               *TimeallocUsage*
+
+Welcome to the Timealloc Plugin for Vim! There's no time so ...
+... here we go!
+
+Basic Syntax of *.ta timealloc file:
+
+  # Comments look like this.
+  Wednesday 1/9
+
+  CategoryA (subcategory): 1.5 hours
+  CategoryB: 3 hours
+  CategoryC (subcategory (subcategory)) : .5 hours
+  CategoryA : .25 hours
+  CategoryD (subcategory (subcategory)): 1.5 hours
+
+  09:00-19:15 20:30-23:15 (13 hours)
+
+Ex-Commands:
+
+:TimeallocDay()    Inserts 'Weekday M/D' to eol.
+:TimeallocTime()   Inserts a time stamp  to eol.
+:TimeallocNew()    Inserts a new category line to eol.
+:TimeallocUpdate() Updates hours in a time stamp line at eol.
+
+:TADay             Inserts 'Weekday M/D' to eol.
+:TATime            Inserts a time stamp  to eol.
+:TANew             Inserts a new category line to eol.
+:TAUpdate          Updates hours in a time stamp line at eol.
+
+====================================================================
+MAPPINGS                                         *TimeallocMappings*
+
+o                  Typing 'o' in normal mode will bring cursor to
+                   begining of line bellow.
+
+====================================================================
+LICENSE                                           *TimeallocLicense*
+
+MIT License, for more informtion visit:
+  https://github.com/gthomsen/time-allocations/blob/master/LICENSE
+
+====================================================================
+BUGS                                                 *TimeallocBugs*
+
+000                It is possible double dip on repeated time stamps
+001                It is possible erase a category line via 'tahrs'
+                   command/abbreviation.
+
+====================================================================
+CHANGELOG                                       *TimeallocChangelog*
+
+1.00.00            I'm brand new, make me cooler!
+
+====================================================================
+CREDITS                                           *TimeallocCredits*
+
+The orginal idea behind the syntax for Timealloc goes to gthomsen on
+GitHub, whose passion for analyzing time far exceeds my own. As for
+myself, I just like to writing things for Vim. Checkout gthomsen's
+time-allocations repository for more goodies, time allocation
+analysis tools, and future updates (there's even an Emacs
+implementation for the closet-Emacs in all of us :O ).
+
+Repository: https://github.com/gthomsen/time-allocations
+

--- a/vim-timealloc/ftdetect/timealloc.vim
+++ b/vim-timealloc/ftdetect/timealloc.vim
@@ -1,0 +1,5 @@
+" Vim timealloc ftdetect file
+" Language:   TA-Lang
+" Maintainer: Polarsky
+
+autocmd BufRead,BufNewFile *.ta  set filetype=timealloc

--- a/vim-timealloc/plugin/timealloc.vim
+++ b/vim-timealloc/plugin/timealloc.vim
@@ -1,0 +1,59 @@
+" Vim timealloc plugin file
+" Language:   TA-Lang
+" Maintainer: Polarsky
+
+if exists('g:loaded_timealloc')
+  finish
+endif
+let g:loaded_timealloc = 1
+
+"===========================================================
+" Global(s)
+"===========================================================
+" Global for time granularity
+let g:TimeallocGranularity = 15
+
+"===========================================================
+" Functions: Drawing
+"===========================================================
+" Print functions:
+"   Day
+function! TimeallocDay()
+  let str = strftime( "%A %-m/%-d" )
+  call timealloc#AppendToCurrentLine( str )
+endfunction
+
+"   Time
+function! TimeallocTime()
+  let str = timealloc#GetTimeRange()
+  call timealloc#AppendToCurrentLine( str )
+endfunction
+
+"   New (category entry)
+function! TimeallocNew()
+  call timealloc#AppendToCurrentLine( 'XXX (XXX (XXX)): XXX hours' )
+endfunction
+
+"   Update Hours (Update to time stamp line)
+function! TimeallocUpdate()
+  let str = timealloc#UpdateTimeStampLine()
+  call timealloc#SetCurrLine( str )
+endfunction
+
+"===========================================================
+" Commands
+"===========================================================
+" NOTE: User may use these to map commands to key bindings
+command! TADay    call TimeallocDay()
+command! TATime   call TimeallocTime()
+command! TANew    call TimeallocNew()
+command! TAUpdate call TimeallocUpdate()
+
+"===========================================================
+" Bindings
+"===========================================================
+" Timealloc filetype specific commands
+augroup timealloc
+  autocmd!
+  autocmd Filetype timealloc nnoremap <buffer> o o<esc>0Di
+augroup END

--- a/vim-timealloc/syntax/timealloc.vim
+++ b/vim-timealloc/syntax/timealloc.vim
@@ -1,0 +1,53 @@
+" Vim Timealloc syntax file
+" Language:   TA-Lang
+" Maintainer: Polarsky
+
+if exists("b:current_syntax")
+  finish
+endif
+
+" Timealloc Keywords for special emphasis
+syn keyword TimeallocTodo    TODO FIXME XXX EPS 000 contained
+syn keyword TimeallocFill    TODO FIXME XXX EPS 000
+syn keyword TimeallocDays    Sunday Monday Tuesday Wednesday Thursday Friday Saturday
+syn keyword TimeallocDays    Sun    Mon    Tues    Wed       Thurs    Fri    Sat
+syn keyword TimeallocHours   HOURS Hours Hrs hours hrs
+
+" Comments
+syn match   TimeallocComment "#.*$"  display contains=TimeallocTodo,@Spell
+
+" Numericals
+syn match   TimeallocNumber  "\<\d\>"                                 display
+syn match   TimeallocNumber  "\<[0-9]\d\+\>"                          display
+syn match   TimeallocNumber  "\<\d\+[jJ]\>"                           display
+syn match   TimeallocFloat   "\.\d\+\%([eE][+-]\=\d\+\)\=[jJ]\=\>"    display
+syn match   TimeallocFloat   "\<\d\+[eE][+-]\=\d\+[jJ]\=\>"           display
+syn match   TimeallocFloat   "\<\d\+\.\d*\%([eE][+-]\=\d\+\)\=[jJ]\=" display
+
+" Identifiers
+syn match   TimeallocParen   "[(|)|):]"                   display
+syn match   TimeallocDate    "\s*[0-9]*[0-9]/[0-9]*[0-9]" display
+syn match   TimeallocStamp   "[0-9][0-9]:[0-9][0-9]"      display
+
+if version >= 508 || !exists("did_timealloc_syn_inits")
+  if version <= 508
+    let did_timealloc_syn_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+
+  " link matches to native vim highlight groups
+  HiLink TimeallocTodo    Todo
+  HiLink TimeallocFill    Todo
+  HiLink TimeallocDays    VisualNOS
+  HiLink TimeallocHours   Statement
+  HiLink TimeallocComment Comment
+  HiLink TimeallocFloat   Float
+  HiLink TimeallocNumber  Number
+  HiLink TimeallocParen   Define
+  HiLink TimeallocDate    VisualNOS
+  HiLink TimeallocStamp   Type
+endif
+
+let b:current_syntax = "timealloc"


### PR DESCRIPTION
Description:
  * Added Vim plugin to support easy documentation
    of *.ta (time allocation) files. vim-timealloc
    has similar behavior as emacs major mode but
    for brought to vim in form of commands that
    can be easily mapped to key bindings by user.